### PR TITLE
disable claim button until era and day are selected

### DIFF
--- a/src/dialogs/claimVeth.js
+++ b/src/dialogs/claimVeth.js
@@ -122,7 +122,8 @@ export const ClaimVeth = () => {
 			</Flex>
 
 			<Flex flexFlow='column' h='20%'>
-				<Button w='100%'
+				<Button isDisabled={!(era && day)}
+					w='100%'
 					isLoading={submitingTx}
 					loadingText='Submitting'
 					onClick={() => {


### PR DESCRIPTION
Sometimes people report a "Something bad happened". It's possible they tried to claim without selecting both an era and a day. Disable the claim button until both are selected.