### PR TITLE
prevent burn or claim without prerequisites

### DIFF
--- a/src/dialogs/burnEther.js
+++ b/src/dialogs/burnEther.js
@@ -8,7 +8,7 @@ import {
 import { useWallet } from 'use-wallet'
 import { getCurrentBurn, getEmission } from '../common/ethereum'
 import { getVetherValueStrict, prettifyCurrency } from '../common/utils'
-import { failed, rejected, insufficientBalance, destroyed } from '../messages'
+import { failed, rejected, insufficientBalance, destroyed, walletNotConnected, amountOfEthToBurnNotEntered } from '../messages'
 
 export const BurnEther = () => {
 
@@ -77,44 +77,50 @@ export const BurnEther = () => {
 					isLoading={working}
 					loadingText='Submitting'
 					onClick={() => {
-						if (wallet.account) {
-							setWorking(true)
-							const provider = new ethers.providers.Web3Provider(wallet.ethereum)
-							const signer = provider.getSigner(0)
-							signer.sendTransaction({
-								to: defaults.network.address.vether,
-								value: ethers.utils.parseEther(amount),
-							})
-								.then((tx) => {
-									tx.wait().then(() => {
-										setWorking(false)
-										toast(destroyed)
-									}).catch((err) => {
-										setWorking(false)
-										console.log('Error code is:' + err.code)
-										console.log('Error:' + err)
-										toast(failed)
-									})
-								})
-								.catch((err) => {
-									if(err.code === 'INSUFFICIENT_FUNDS') {
-										setWorking(false)
-										console.log('Insufficient balance: Your account balance is insufficient.')
-										toast(insufficientBalance)
-									}
-									else if(err.code === 4001) {
-										setWorking(false)
-										console.log('Transaction rejected: Your have decided to reject the transaction..')
-										toast(rejected)
-									}
-									else {
-										setWorking(false)
-										console.log('Error code is:' + err.code)
-										console.log('Error:' + err)
-										toast(failed)
-									}
-								})
+						if (!wallet.account) {
+							toast(walletNotConnected)
+							return
 						}
+						if (!amount) {
+							toast(amountOfEthToBurnNotEntered)
+							return
+						}
+						setWorking(true)
+						const provider = new ethers.providers.Web3Provider(wallet.ethereum)
+						const signer = provider.getSigner(0)
+						signer.sendTransaction({
+							to: defaults.network.address.vether,
+							value: ethers.utils.parseEther(amount),
+						})
+							.then((tx) => {
+								tx.wait().then(() => {
+									setWorking(false)
+									toast(destroyed)
+								}).catch((err) => {
+									setWorking(false)
+									console.log('Error code is:' + err.code)
+									console.log('Error:' + err)
+									toast(failed)
+								})
+							})
+							.catch((err) => {
+								if(err.code === 'INSUFFICIENT_FUNDS') {
+									setWorking(false)
+									console.log('Insufficient balance: Your account balance is insufficient.')
+									toast(insufficientBalance)
+								}
+								else if(err.code === 4001) {
+									setWorking(false)
+									console.log('Transaction rejected: Your have decided to reject the transaction..')
+									toast(rejected)
+								}
+								else {
+									setWorking(false)
+									console.log('Error code is:' + err.code)
+									console.log('Error:' + err)
+									toast(failed)
+								}
+							})
 					}}>
 					Burn
 				</Button>

--- a/src/dialogs/claimVeth.js
+++ b/src/dialogs/claimVeth.js
@@ -10,7 +10,7 @@ import {
 	getClaimDayNums, getEmissionEra, getShare, claimShare,
 } from '../common/ethereum'
 import { getAvailableEras, prettifyCurrency } from '../common/utils'
-import { claimed, failed, rejected } from '../messages'
+import { claimed, failed, rejected, walletNotConnected, eraNotSelected, dayNotSelected } from '../messages'
 
 export const ClaimVeth = () => {
 
@@ -127,35 +127,45 @@ export const ClaimVeth = () => {
 					isLoading={submitingTx}
 					loadingText='Submitting'
 					onClick={() => {
-						if (wallet.account) {
-							setSubmitingTx(true)
-							const provider = new ethers.providers.Web3Provider(wallet.ethereum)
-							claimShare(era, day, provider)
-								.then((tx) => {
-									tx.wait().then(() => {
-										setSubmitingTx(false)
-										toast(claimed)
-									}).catch((err) => {
-										setSubmitingTx(false)
-										console.log('Error code is:' + err.code)
-										console.log('Error:' + err)
-										toast(failed)
-									})
-								})
-								.catch((err) => {
-									if(err.code === 4001) {
-										setSubmitingTx(false)
-										console.log('Transaction rejected: Your have decided to reject the transaction.')
-										toast(rejected)
-									}
-									else {
-										setSubmitingTx(false)
-										console.log('Error code is:' + err.code)
-										console.log('Error:' + err)
-										toast(failed)
-									}
-								})
+						if (!wallet.account) {
+							toast(walletNotConnected)
+							return
 						}
+						if (!era) {
+							toast(eraNotSelected)
+							return
+						}
+						if (!day) {
+							toast(dayNotSelected)
+							return
+						}
+						setSubmitingTx(true)
+						const provider = new ethers.providers.Web3Provider(wallet.ethereum)
+						claimShare(era, day, provider)
+							.then((tx) => {
+								tx.wait().then(() => {
+									setSubmitingTx(false)
+									toast(claimed)
+								}).catch((err) => {
+									setSubmitingTx(false)
+									console.log('Error code is:' + err.code)
+									console.log('Error:' + err)
+									toast(failed)
+								})
+							})
+							.catch((err) => {
+								if(err.code === 4001) {
+									setSubmitingTx(false)
+									console.log('Transaction rejected: Your have decided to reject the transaction.')
+									toast(rejected)
+								}
+								else {
+									setSubmitingTx(false)
+									console.log('Error code is:' + err.code)
+									console.log('Error:' + err)
+									toast(failed)
+								}
+							})
 					}}>
 					Claim
 				</Button>

--- a/src/messages/index.js
+++ b/src/messages/index.js
@@ -54,6 +54,43 @@ const failed = {
 	position: defaults.toast.position,
 }
 
+const walletNotConnected = {
+	title: 'Wallet not connected',
+	description: 'Please connect a wallet.',
+	status: 'error',
+	duration: defaults.toast.duration,
+	isClosable: defaults.toast.closable,
+	position: defaults.toast.position,
+}
+
+const eraNotSelected = {
+	title: 'Era not selected',
+	description: 'Please select an emission era.',
+	status: 'error',
+	duration: defaults.toast.duration,
+	isClosable: defaults.toast.closable,
+	position: defaults.toast.position,
+}
+
+const dayNotSelected = {
+	title: 'Day not selected',
+	description: 'Please select an emission day.',
+	status: 'error',
+	duration: defaults.toast.duration,
+	isClosable: defaults.toast.closable,
+	position: defaults.toast.position,
+}
+
+const amountOfEthToBurnNotEntered = {
+	title: 'Amount of ETH to burn not entered',
+	description: 'Please enter the amount of ETH to burn.',
+	status: 'error',
+	duration: defaults.toast.duration,
+	isClosable: defaults.toast.closable,
+	position: defaults.toast.position,
+}
+
 export {
 	connected, failed, rejected, insufficientBalance, destroyed, claimed,
+	walletNotConnected, eraNotSelected, dayNotSelected, amountOfEthToBurnNotEntered,
 }


### PR DESCRIPTION
This displays toasts urging the user to complete prerequisite steps first if they try to burn or claim without them.

There's less going on here than it looks like. I reduced the indentation depth of the code in the `onClick` handlers, but the code is the same.